### PR TITLE
Correcting Grid::MakeEvent in "all in one"

### DIFF
--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -269,7 +269,7 @@ void Grid<dim>::MakeEvent() {
     for (auto s : ModelParameters.IterSpecies()) {
         if (TotalPopulation[s] > 0) {
             dis[2 * s + 0] = TotalDeathRate[s];
-            dis[2 * s + 1] = TotalPopulation[s] * ModelParameters.GetD(s);
+            dis[2 * s + 1] = TotalPopulation[s] * ModelParameters.GetB(s);
         }
     }
     auto t = boost::random::discrete_distribution<>(dis)(Rnd);

--- a/src/model_parameters.cpp
+++ b/src/model_parameters.cpp
@@ -92,6 +92,10 @@ double ModelParameters::GetD(size_t species) const {
     return D[species];
 }
 
+double ModelParameters::GetB(size_t species) const {
+    return B[species];
+}
+
 const boost::math::cubic_b_spline<double>& ModelParameters::GetBirthSpline(size_t species) const {
     return BirthReverseKernel[species];
 }

--- a/src/model_parameters.h
+++ b/src/model_parameters.h
@@ -36,6 +36,7 @@ private:
 public:
     double GetInteraction(size_t speciesA, size_t speciesB, double distance) const;
     double GetD(size_t species) const;
+    double GetB(size_t species) const;
     const boost::math::cubic_b_spline<double>& GetBirthSpline(size_t species) const;
     double GetMaximumCutoff() const;
 }; 


### PR DESCRIPTION
It seems that the program did not take into account the values of the b parameters for multi-species simulation ("all in one" branch). I think I've made it so that it now has to take into account. Please check and accept the PR.